### PR TITLE
Dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.0.3",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hive-multisig-sdk",
-      "version": "0.0.3",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "@hiveio/dhive": "^1.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "1.0.0",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hive-multisig-sdk",
-      "version": "1.0.0",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
         "@hiveio/dhive": "^1.2.6",
@@ -85,7 +85,7 @@
         "is-fullwidth-code-point": "^3.0.0",
         "is-stream": "^2.0.1",
         "jsbi": "^3.2.5",
-        "keychain-sdk": "^0.4.0",
+        "keychain-sdk": "^0.5.0",
         "kuler": "^2.0.0",
         "logform": "^2.5.1",
         "long": "^3.2.0",
@@ -2721,9 +2721,9 @@
       }
     },
     "node_modules/hive-keychain-commons": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/hive-keychain/hive-keychain-commons.git#c670c7f30c658e1d75f64b75d1a080ed1e33b655",
-      "license": "ISC",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/hive-keychain-commons/-/hive-keychain-commons-1.2.2.tgz",
+      "integrity": "sha512-QXFR7q1WSTZStW2cQoanl4bDDj1iSRduvV9n+ZBOQmUgD15ggEJOqFr2Jao5qYP8I5x2cGTsw60Vq3G22yMIFw==",
       "dependencies": {
         "@hiveio/dhive": "^1.2.5",
         "moment": "^2.29.4",
@@ -3675,14 +3675,14 @@
       }
     },
     "node_modules/keychain-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/keychain-sdk/-/keychain-sdk-0.4.0.tgz",
-      "integrity": "sha512-WcNXUNAO4AGHORgrPh8I7rJbjCj8QD3VDylFH2A8aYmEqf3v9RWzIoIvUmtFpg1vlQAhM8COt7CRWrnczRQuWQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/keychain-sdk/-/keychain-sdk-0.5.0.tgz",
+      "integrity": "sha512-Mi7H7fviW6ibiu8x3MWLzKIrV1221PJ+pMik/x4W3yRDRzkiUjpjL07iDyXFFiEFTG9kL8VzGnQMc/gfO8biWg==",
       "dependencies": {
         "@hiveio/dhive": "^1.2.5",
         "@types/node": "^18.11.18",
         "axios": "^1.3.0",
-        "hive-keychain-commons": "^1.1.0",
+        "hive-keychain-commons": "^1.2.2",
         "uuid": "^9.0.0"
       }
     },
@@ -7320,8 +7320,9 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
     "hive-keychain-commons": {
-      "version": "git+ssh://git@github.com/hive-keychain/hive-keychain-commons.git#c670c7f30c658e1d75f64b75d1a080ed1e33b655",
-      "from": "hive-keychain-commons@^1.1.0",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/hive-keychain-commons/-/hive-keychain-commons-1.2.2.tgz",
+      "integrity": "sha512-QXFR7q1WSTZStW2cQoanl4bDDj1iSRduvV9n+ZBOQmUgD15ggEJOqFr2Jao5qYP8I5x2cGTsw60Vq3G22yMIFw==",
       "requires": {
         "@hiveio/dhive": "^1.2.5",
         "moment": "^2.29.4",
@@ -8045,14 +8046,14 @@
       "dev": true
     },
     "keychain-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/keychain-sdk/-/keychain-sdk-0.4.0.tgz",
-      "integrity": "sha512-WcNXUNAO4AGHORgrPh8I7rJbjCj8QD3VDylFH2A8aYmEqf3v9RWzIoIvUmtFpg1vlQAhM8COt7CRWrnczRQuWQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/keychain-sdk/-/keychain-sdk-0.5.0.tgz",
+      "integrity": "sha512-Mi7H7fviW6ibiu8x3MWLzKIrV1221PJ+pMik/x4W3yRDRzkiUjpjL07iDyXFFiEFTG9kL8VzGnQMc/gfO8biWg==",
       "requires": {
         "@hiveio/dhive": "^1.2.5",
         "@types/node": "^18.11.18",
         "axios": "^1.3.0",
-        "hive-keychain-commons": "^1.1.0",
+        "hive-keychain-commons": "^1.2.2",
         "uuid": "^9.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1",
+  "version": "0.1.0",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "1.0.0",
+  "version": "0.0.3",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.0.3",
+  "version": "0.0.3.1",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -81,7 +81,7 @@
     "is-fullwidth-code-point": "^3.0.0",
     "is-stream": "^2.0.1",
     "jsbi": "^3.2.5",
-    "keychain-sdk": "^0.4.0",
+    "keychain-sdk": "^0.5.0",
     "kuler": "^2.0.0",
     "logform": "^2.5.1",
     "long": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.0.3.1",
+  "version": "0.0.4",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.0.5",
+  "version": "0.1",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "sdk for hive multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "SDK for Hive Multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-multisig-sdk",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "SDK for Hive Multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hive-multisig-sdk",
   "version": "0.1.9",
-  "description": "sdk for hive multisig",
+  "description": "SDK for Hive Multisig",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
@@ -161,7 +161,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/carlodizon03/hive-multisig-sdk.git"
+    "url": "git+https://github.com/hive-keychain/hive-multisig-sdk"
   },
   "keywords": [
     "hive",
@@ -171,7 +171,7 @@
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/carlodizon03/hive-multisig-sdk/issues"
+    "url": "https://github.com/hive-keychain/hive-multisig-sdk/issues"
   },
-  "homepage": "https://github.com/carlodizon03/hive-multisig-sdk#readme"
+  "homepage": "https://github.com/hive-keychain/hive-multisig-sdk#readme"
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { Transaction, TransferOperation, VoteOperation } from '@hiveio/dhive';
 import { describe, expect, it } from '@jest/globals';
-import { HiveMultisigSDK } from '.';
+import { HiveMultisig } from '.';
 
 describe('Test Get Username From Tx', () => {
   it('should return username from transfer operation', () => {
@@ -21,7 +21,7 @@ describe('Test Get Username From Tx', () => {
         ] as TransferOperation,
       ],
     };
-    expect(HiveMultisigSDK.getUsernameFromTransaction(tx)).toBe('hi');
+    expect(HiveMultisig.getUsernameFromTransaction(tx)).toBe('hi');
   });
 
   it('should return username from two operations', () => {
@@ -51,7 +51,7 @@ describe('Test Get Username From Tx', () => {
         ] as VoteOperation,
       ],
     };
-    expect(HiveMultisigSDK.getUsernameFromTransaction(tx)).toBe('hi');
+    expect(HiveMultisig.getUsernameFromTransaction(tx)).toBe('hi');
   });
 
   it('should return undefined when two operations have different usernames', () => {
@@ -81,6 +81,6 @@ describe('Test Get Username From Tx', () => {
         ] as VoteOperation,
       ],
     };
-    expect(HiveMultisigSDK.getUsernameFromTransaction(tx)).toBe(undefined);
+    expect(HiveMultisig.getUsernameFromTransaction(tx)).toBe(undefined);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -552,7 +552,7 @@ multisig.signTransaction(data)
             let signerList: RequestSignatureSigner[] = [];
             if (potentialSigners.length > 0) {
               const encodedTransaction = await this.keychain.encodeWithKeys({
-                username: broadcaster.toString(),
+                username: data.initiator.username,
                 publicKeys: potentialSigners.map((k) => {
                   return k[0];
                 }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,12 +207,12 @@ export class HiveMultisigSDK {
           );
         } else {
           reject(
-            new Error('Error while signing buffer during singleSignerConnect'),
+            new Error('Error while signing buffer during signerConnect'),
           );
         }
       } catch (error: any) {
         const errorMessage =
-          'Error occurred during singleSignerConnect: ' + error.message;
+          'Error occurred during signerConnect: ' + error.message;
         reject(new Error(errorMessage));
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,12 +118,13 @@ export class HiveMultisig {
     return HiveMultisig.instance;
   }
 
-  public static resetInstance( window: Window,
-    options?: MultisigOptions): HiveMultisig {
+  public static resetInstance(
+    window: Window,
+    options?: MultisigOptions,
+  ): HiveMultisig {
     HiveMultisig.socket.disconnect();
     HiveMultisig.instance = new HiveMultisig(window, options);
     return HiveMultisig.instance;
-
   }
 
   api = {
@@ -466,32 +467,6 @@ multisig.signTransaction(data)
 
   utils = {
     /**
-     * @description
-     * A function tha returns the list of potential signers' public key and weight
-     *
-     * @param username
-     * @param keyType the transaction key type or method
-     * @returns [string,number][] List of publicKey with corresponding weight
-     */
-    getSigners: async (
-      username: string,
-      keyType: KeychainKeyTypes,
-    ): Promise<[string, number][]> => {
-      return new Promise(async (resolve, reject) => {
-        try {
-          let signers: [string, number][] = [];
-          signers = await HiveUtils.getPotentialSigners(username, keyType);
-          if (signers.length === 0) {
-            reject(`${username} not found`);
-          }
-          resolve(signers);
-        } catch (error: any) {
-          reject(
-            new Error('error occured during getSigners: ' + error.message),
-          );
-        }
-      });
-    } /**
     * @description
     * Encodes the transaction data using the keychain. 
     * @param data The object containing transaction encoding details.
@@ -508,7 +483,7 @@ multisig.signTransaction(data)
          };
          const encodedTxObj = await multisig.utils.encodeTransaction(txEncode);
          console.log(encodedTxObj);
-     */,
+     */
     encodeTransaction: (
       data: IEncodeTransaction,
     ): Promise<RequestSignatureMessage> => {
@@ -789,7 +764,7 @@ multisig.signTransaction(data)
    * @returnsA username if a single one is found, undefined if the tx is badly formatted or if two different signers are needed.
    * Abort operations in these cases.
    */
-  static getUsernameFromTransaction = (tx: Transaction) => {
+  private static getUsernameFromTransaction = (tx: Transaction) => {
     let username;
     if (!tx.operations || !tx.operations.length) return;
     for (const op of tx.operations) {
@@ -958,4 +933,32 @@ multisig.signTransaction(data)
     }
     return username;
   };
+
+  /**
+   * @description
+   * A function tha returns the list of potential signers' public key and weight
+   *
+   * @param username
+   * @param keyType the transaction key type or method
+   * @returns [string,number][] List of publicKey with corresponding weight
+   */
+  static getSigners = async (
+    username: string,
+    keyType: KeychainKeyTypes,
+  ): Promise<[string, number][]> => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        let signers: [string, number][] = [];
+        signers = await HiveUtils.getPotentialSigners(username, keyType);
+        if (signers.length === 0) {
+          reject(`${username} not found`);
+        }
+        resolve(signers);
+      } catch (error: any) {
+        reject(new Error('error occured during getSigners: ' + error.message));
+      }
+    });
+  };
 }
+
+HiveMultisig.getAuthorities;

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,6 +518,7 @@ multisig.signTransaction(data)
     ): Promise<RequestSignatureMessage> => {
       return new Promise<RequestSignatureMessage>(async (resolve, reject) => {
         try {
+          console.log('sdk data', JSON.stringify(data));
           const signature = await this.keychain.signTx({
             username: data.initiator.username.toString(),
             tx: data.transaction,

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,8 @@ import { HiveUtils, getPublicKeys } from './utils/hive.utils';
  * @export
  * @class
  */
-export class HiveMultisigSDK {
-  private static instance: HiveMultisigSDK;
+export class HiveMultisig {
+  private static instance: HiveMultisig;
   window: Window;
   options?: MultisigOptions;
   keychain: KeychainSDK;
@@ -111,11 +111,11 @@ export class HiveMultisigSDK {
   public static getInstance(
     window: Window,
     options?: MultisigOptions,
-  ): HiveMultisigSDK {
-    if (!HiveMultisigSDK.instance) {
-      HiveMultisigSDK.instance = new HiveMultisigSDK(window, options);
+  ): HiveMultisig {
+    if (!HiveMultisig.instance) {
+      HiveMultisig.instance = new HiveMultisig(window, options);
     }
-    return HiveMultisigSDK.instance;
+    return HiveMultisig.instance;
   }
 
   api = {
@@ -520,7 +520,7 @@ multisig.signTransaction(data)
             return;
           }
           const signedTransaction = signature.result;
-          const broadcaster = HiveMultisigSDK.getUsernameFromTransaction(
+          const broadcaster = HiveMultisig.getUsernameFromTransaction(
             data.transaction,
           );
           if (broadcaster) {
@@ -649,7 +649,7 @@ multisig.signTransaction(data)
                       jsonString.replace('#', ''),
                     );
                     const validAuth =
-                      await HiveMultisigSDK.validateInitiatorOverBroadcaster(
+                      await HiveMultisig.validateInitiatorOverBroadcaster(
                         signRequest.initiator,
                         signRequest.keyType,
                         decodedTx,
@@ -704,7 +704,7 @@ multisig.signTransaction(data)
     keyType: KeychainKeyTypes,
     transaction: SignedTransaction,
   ) => {
-    const txUsername = HiveMultisigSDK.getUsernameFromTransaction(transaction);
+    const txUsername = HiveMultisig.getUsernameFromTransaction(transaction);
     if (!txUsername) {
       return undefined;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export class HiveMultisigSDK {
   options?: MultisigOptions;
   keychain: KeychainSDK;
   socket: io.Socket;
+  
   constructor(window: Window, options?: MultisigOptions) {
     this.window = window;
     this.keychain = new KeychainSDK(this.window);
@@ -456,7 +457,7 @@ multisig.signTransaction(data)
               publicKeys: potentialSigners.map((k) => {
                 return k[0];
               }),
-              message: `#${JSON.stringify(signedTransaction)}`,
+              message: `#${JSON.stringify(data.transaction)}`,
               method: data.method,
             });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -756,6 +756,21 @@ multisig.signTransaction(data)
     return undefined;
   };
 
+  static get2FASigners = async (
+    transaction: Transaction,
+    method: KeychainKeyTypes,
+  ) => {
+    const broadcaster = HiveMultisig.getUsernameFromTransaction(transaction);
+    if (broadcaster) {
+      let potentialSigners: [string, number][] =
+        await HiveUtils.getPotentialSigners(broadcaster.toString(), method);
+      if (potentialSigners.length === 0) {
+        return [];
+      }
+      return HiveUtils.get2FABots(potentialSigners);
+    }
+  };
+
   /**
    * @description
    * Get the username that will request the broadcast of a given tx

--- a/src/index.ts
+++ b/src/index.ts
@@ -854,7 +854,7 @@ multisig.signTransaction(data)
    * @returnsA username if a single one is found, undefined if the tx is badly formatted or if two different signers are needed.
    * Abort operations in these cases.
    */
-  private static getUsernameFromTransaction = (tx: Transaction) => {
+  static getUsernameFromTransaction = (tx: Transaction) => {
     let username;
     if (!tx.operations || !tx.operations.length) return;
     for (const op of tx.operations) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -566,6 +566,7 @@ multisig.signTransaction(data)
                   var result = encodedTx[potentialSigners[i][0]];
                   var metaData = twoFACodes
                     ? await HiveMultisig.getMetadata(
+                        broadcaster.toString(),
                         twoFACodes,
                         potentialSigners[i][0],
                         data.method,
@@ -732,6 +733,7 @@ multisig.signTransaction(data)
   };
 
   static getMetadata = async (
+    username: string,
     twoFACodes: any,
     publicKey: string,
     method: KeychainKeyTypes,
@@ -742,9 +744,9 @@ multisig.signTransaction(data)
       if (twoFACodes[botName]) {
         let twoFa: TwoFACodes = {};
         let metadata: RequestSignatureSignerMetadata = { twoFACodes: {} };
-
+        console.log('username', username);
         const encodingResult = await keychain.encodeWithKeys({
-          username: botName,
+          username,
           publicKeys: [publicKey],
           message: `#${twoFACodes[botName]}`,
           method: method,

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,6 @@ export class HiveMultisigSDK {
           'Error occurred during signerConnect: ' + error.message;
         reject(new Error(errorMessage));
       }
-
         }
     );
   };
@@ -449,8 +448,6 @@ multisig.signTransaction(data)
           const threshold = await HiveUtils.getThreshold(broadcaster.toString(),data.method);
           let potentialSigners: [string, number][] =
             await HiveUtils.getPotentialSigners(broadcaster.toString(),data.method);
-            console.log(`potentialSigners`);
-            console.log(potentialSigners);
           potentialSigners = potentialSigners.filter((signer) => signer[0]!==data.initiator.publicKey);
           let signerList: RequestSignatureSigner[] = [];
           if (potentialSigners.length > 0) {
@@ -693,6 +690,7 @@ multisig.signTransaction(data)
         txUsername.toString(),
         keyType,
       );
+     
       if(!initiatorPublicKeys){
         return undefined;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -744,7 +744,6 @@ multisig.signTransaction(data)
       if (twoFACodes[botName]) {
         let twoFa: TwoFACodes = {};
         let metadata: RequestSignatureSignerMetadata = { twoFACodes: {} };
-        console.log('username', username);
         const encodingResult = await keychain.encodeWithKeys({
           username,
           publicKeys: [publicKey],

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,7 @@ export class HiveMultisig {
               username: data.username,
               message: data.username,
               method: data.keyType,
+              title: data.title,
             } as SignBuffer);
             if (signBuffer.success) {
               let publicKey = signBuffer.publicKey

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,9 @@ export class HiveMultisig {
               username: data.username,
               message: data.username,
               method: data.keyType,
-              title: data.title,
+              title:
+                data.title ||
+                `Hive Multisig Login: verify ${data.keyType} key for @${data.username}`,
             } as SignBuffer);
             if (signBuffer.success) {
               let publicKey = signBuffer.publicKey

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,9 +198,7 @@ export class HiveMultisig {
               username: data.username,
               message: data.username,
               method: data.keyType,
-              title:
-                data.title ||
-                `Hive Multisig Login: verify ${data.keyType} key for @${data.username}`,
+              title: data.title || `Hive Multisig Login`,
             } as SignBuffer);
             if (signBuffer.success) {
               let publicKey = signBuffer.publicKey

--- a/src/interfaces/signature-request.ts
+++ b/src/interfaces/signature-request.ts
@@ -9,8 +9,8 @@ export interface SignatureRequest {
   initiator: string;
   locked: boolean;
   broadcasted?: boolean;
-  createdAt?:Date;
-  updatedAt?:Date;
+  createdAt?: Date;
+  updatedAt?: Date;
   signers: Signer[];
-  status?:string;
+  status: string;
 }

--- a/src/interfaces/socket-message-interface.ts
+++ b/src/interfaces/socket-message-interface.ts
@@ -31,19 +31,20 @@ export interface NotifyTxBroadcastedMessage extends SocketMessagePayload {
 
 export interface SocketMessagePayload {}
 
-export interface SignerConnect {
+
+export interface SignerConnectMessage extends SocketMessagePayload {
+  publicKey?: string;
+  message?: string;
   username: string;
   keyType: KeychainKeyTypes;
 }
-export interface SignerConnectMessage extends SocketMessagePayload {
-  publicKey: string;
-  message: string;
-  username: string;
-}
+
 
 export interface SignerConnectResponse {
   errors?: SignerConnectError;
   result?: SignerConnectResult;
+  message?: string;
+  publicKey?: string;
 }
 
 export interface SignerConnectResult {

--- a/src/interfaces/socket-message-interface.ts
+++ b/src/interfaces/socket-message-interface.ts
@@ -85,8 +85,12 @@ export interface RequestSignatureSigner {
   encryptedTransaction: string; // Encrypted transaction with signer key
   publicKey: string; // public key of signer
   weight: string;
+  metaData?: RequestSignatureSignerMetadata | undefined;
 }
 
+export interface RequestSignatureSignerMetadata {
+  twoFACodes?: TwoFACodes;
+}
 export interface SignTransactionMessage extends SocketMessagePayload {
   signature: string;
   signerId: number;
@@ -129,4 +133,7 @@ export interface ITransaction {
   username: string;
 }
 
+export interface TwoFACodes {
+  [botName: string]: string;
+}
 export type SignatureRequestCallback = (message: SignatureRequest) => void;

--- a/src/interfaces/socket-message-interface.ts
+++ b/src/interfaces/socket-message-interface.ts
@@ -1,7 +1,5 @@
-import * as Hive from '@hiveio/dhive';
 import { SignedTransaction, Transaction } from '@hiveio/dhive';
 import { KeychainKeyTypes } from 'hive-keychain-commons';
-import { KeychainOptions } from 'keychain-sdk';
 import { SignatureRequest } from './signature-request';
 import { Signer } from './signer';
 
@@ -15,10 +13,9 @@ export enum SocketMessageCommand {
   TRANSACTION_BROADCASTED_NOTIFICATION = 'transaction_broadcasted_notification',
 }
 export interface MultisigOptions {
-  keychainOptions?: KeychainOptions;
   socketAddress: string;
   clientAddress: string;
-  apiAddress:string;
+  apiAddress: string;
 }
 export interface SocketMessage {
   command: string;
@@ -31,14 +28,12 @@ export interface NotifyTxBroadcastedMessage extends SocketMessagePayload {
 
 export interface SocketMessagePayload {}
 
-
 export interface SignerConnectMessage extends SocketMessagePayload {
   publicKey?: string;
   message?: string;
   username: string;
   keyType: KeychainKeyTypes;
 }
-
 
 export interface SignerConnectResponse {
   errors?: SignerConnectError;
@@ -68,7 +63,7 @@ export interface SignerConnectError {
 }
 
 export interface ISignatureRequest {
-  expirationDate: Date|string;
+  expirationDate: Date | string;
   threshold: number;
   keyType: KeychainKeyTypes;
   signers: RequestSignatureSigner[];
@@ -113,12 +108,12 @@ export interface ISignTransaction {
 export interface IEncodeTransaction {
   transaction: Transaction;
   method: KeychainKeyTypes;
-  expirationDate: Date|string;
+  expirationDate: Date | string;
   initiator: {
-    username:string,
-    publicKey: string,
-    weight: number
-  }
+    username: string;
+    publicKey: string;
+    weight: number;
+  };
 }
 
 export interface IDecodeTransaction {
@@ -126,13 +121,12 @@ export interface IDecodeTransaction {
   username: string;
 }
 
-export interface ITransaction{
-  signer:Signer,
-  signatureRequestId:number ,
+export interface ITransaction {
+  signer: Signer;
+  signatureRequestId: number;
   transaction: SignedTransaction;
   method: KeychainKeyTypes;
   username: string;
 }
-
 
 export type SignatureRequestCallback = (message: SignatureRequest) => void;

--- a/src/interfaces/socket-message-interface.ts
+++ b/src/interfaces/socket-message-interface.ts
@@ -68,7 +68,7 @@ export interface SignerConnectError {
 }
 
 export interface ISignatureRequest {
-  expirationDate: Date;
+  expirationDate: Date|string;
   threshold: number;
   keyType: KeychainKeyTypes;
   signers: RequestSignatureSigner[];
@@ -113,7 +113,7 @@ export interface ISignTransaction {
 export interface IEncodeTransaction {
   transaction: Transaction;
   method: KeychainKeyTypes;
-  expirationDate: Date;
+  expirationDate: Date|string;
   initiator: {
     username:string,
     publicKey: string,

--- a/src/interfaces/socket-message-interface.ts
+++ b/src/interfaces/socket-message-interface.ts
@@ -33,6 +33,7 @@ export interface SignerConnectMessage extends SocketMessagePayload {
   message?: string;
   username: string;
   keyType: KeychainKeyTypes;
+  title?: string;
 }
 
 export interface SignerConnectResponse {

--- a/src/utils/hive.utils.ts
+++ b/src/utils/hive.utils.ts
@@ -158,7 +158,12 @@ const get2FABots = async (username: string, method: KeychainKeyTypes) => {
   for (let i = 0; i < authority.account_auths.length; i++) {
     const auth = authority.account_auths[i];
     const account = await HiveUtils.getAccount(auth[0]);
-    const jsonMetadata = JSON.parse(account['json_metadata']);
+    let jsonMetadata;
+    try {
+      jsonMetadata = JSON.parse(account['json_metadata']);
+    } catch (e) {
+      continue;
+    }
     const isMultisigBot = jsonMetadata?.isMultisigBot === true;
     if (isMultisigBot) {
       bots = bots.concat([auth]);

--- a/src/utils/hive.utils.ts
+++ b/src/utils/hive.utils.ts
@@ -10,6 +10,7 @@ const getClient = () => {
     hiveClient = new Client([
       'https://api.hive.blog',
       'https://api.hivekings.com',
+      'https://api.deathwing.me',
       'https://anyx.io',
       'https://api.openhive.network',
     ]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,7 +102,7 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     // "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["dist"],
+  "exclude": ["dist","src/index.test.ts"],
   "include": [
     "src/global.d.ts",
     "src/**/*.ts",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Major refactor and feature additions to the multisig SDK, moving to production-ready endpoints and structured APIs.
> 
> - Rename `HiveMultisigSDK` to `HiveMultisig`; introduce `getInstance`/`resetInstance` and static socket handling
> - New structured APIs: `api.getSignatureRequests`, `wss.subscribe/requestSignatures/signTransaction/broadcastTransaction/onReceiveSignRequest/onBroadcasted`, `utils.encodeTransaction/decodeTransaction/get2FASigners`
> - Add 2FA support: `RequestSignatureSigner.metaData`, `TwoFACodes`, `getMetadata`, and `HiveUtils.get2FABots/getKeyReferences`
> - Default to production URLs (`api.multisig.hive-keychain.com`, `wss://ws.multisig.hive-keychain.com`) and bump `keychain-sdk` to `^0.5.0`
> - Improve encode/decode flow, initiator validation, and broadcaster username detection; adjust interfaces (optional `message/publicKey`, `expirationDate` accepts string, required `status`)
> - `HiveUtils` cleanup: single-account returns, added endpoints, and helpers; minor tsconfig/test additions
> - Update package metadata (repo, homepage) and add unit tests for `getUsernameFromTransaction`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17477ab5a58a3325951d356568232911f708cdf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->